### PR TITLE
Tighten laravel version constraint to prevent vulnerability for CVE-2020-24941

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^7.1.0",
-        "laravel/framework": "^5.3.31 || ^6.0.0",
+        "laravel/framework": "^5.3.31 || ^6.18.35",
         "nesbot/carbon": "^2.37"
     },
     "autoload": {


### PR DESCRIPTION
Link to CVE: https://github.com/advisories/GHSA-w68r-5p45-5rqp